### PR TITLE
Fix test-suite error noise

### DIFF
--- a/varchar/check/test-suite.c
+++ b/varchar/check/test-suite.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/wait.h>
+#include <fcntl.h>
 #include "varchar-check.h"
 
 #define DECL_VARCHAR(name, size) struct { unsigned short len; char arr[size]; } name
@@ -24,6 +25,11 @@ static int verbose = 0;
 static void expect_abort(void (*fn)(void), const char *name) {
     pid_t pid = fork();
     if (pid == 0) {
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDERR_FILENO);
+            close(devnull);
+        }
         fn();
         exit(0);
     } else {


### PR DESCRIPTION
## Summary
- silence expected abort messages during varchar check tests

## Testing
- `make`
- `./test-suite.exe`

------
https://chatgpt.com/codex/tasks/task_b_687c624d40cc8326b13512ee9fa0b006