### PR TITLE
Silence overflow warnings in varchar test suite

### DIFF
--- a/varchar/check/test-suite.c
+++ b/varchar/check/test-suite.c
@@ -54,7 +54,10 @@ static void abort_check_str(void) {
 
 static void abort_zsetlen_overflow(void) {
     DECL_VARCHAR(v, 3);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
     strcpy(v.arr, "abcd");
+#pragma GCC diagnostic pop
     VARCHAR_ZSETLEN(v);
 }
 
@@ -72,7 +75,10 @@ static void abort_copy_small_dest(void) {
 
 static void abort_copy_in_overflow(void) {
     DECL_VARCHAR(v, 3);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
     VARCHAR_COPY_IN(v, "abcd");
+#pragma GCC diagnostic pop
 }
 
 static void abort_copy_out_small(void) {


### PR DESCRIPTION
## Summary
- suppress GCC `-Wstringop-overflow` noise from negative test cases using pragmas

## Testing
- `make -C varchar/check`
- `./test-suite.exe --verbose`

------
https://chatgpt.com/codex/tasks/task_b_687c652e22ec8326915701dbf42d7399